### PR TITLE
Add support for ignoring unknown dictionary keys

### DIFF
--- a/serde/field/core.py
+++ b/serde/field/core.py
@@ -336,15 +336,18 @@ class ModelField(InstanceField):
         Person(name='Beyonce', birthday=Birthday(day=4, month='September'))
     """
 
-    def __init__(self, model, **kwargs):
+    def __init__(self, model, strict=True, **kwargs):
         """
         Create a new ModelField.
 
         Args:
             model: the Model class that this Field wraps.
+            strict (bool): if set to False then no exception will be raised when
+                unknown dictionary keys are present when deserializing.
             **kwargs: keyword arguments for the `InstanceField` constructor.
         """
         super().__init__(model, **kwargs)
+        self.strict = strict
 
     def serialize(self, value):
         """
@@ -369,7 +372,7 @@ class ModelField(InstanceField):
         Returns:
             Model: the deserialized model.
         """
-        value = self.type.from_dict(value)
+        value = self.type.from_dict(value, strict=self.strict)
         return super().deserialize(value)
 
 

--- a/serde/model.py
+++ b/serde/model.py
@@ -238,12 +238,14 @@ class Model(metaclass=ModelType):
             self.validate_field(name, field)
 
     @classmethod
-    def from_dict(cls, d):
+    def from_dict(cls, d, strict=True):
         """
         Convert a dictionary to an instance of this Model.
 
         Args:
             d (dict): a serialized version of this Model.
+            strict (bool): if set to False then no exception will be raised when
+                unknown dictionary keys are present.
 
         Returns:
             Model: an instance of this Model.
@@ -285,7 +287,7 @@ class Model(metaclass=ModelType):
 
                 kwargs[name] = value
 
-        if d:
+        if strict and d:
             unknowns = ', '.join('{!r}'.format(k) for k in d.keys())
             plural = '' if len(d.keys()) == 1 else 's'
             raise DeserializationError('unknown dictionary key{} {}'.format(plural, unknowns))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -268,6 +268,12 @@ class TestModel:
         example = Example.from_dict({'a': 5, 'b': {'x': 10.5}})
         assert isinstance(example.b, SubExample)
 
+        with raises(DeserializationError):
+            Example.from_dict({'a': 5, 'b': {'x': 10.5}, 'z': True})
+
+        example = Example.from_dict({'a': 5, 'b': {'x': 10.5}, 'z': True}, strict=False)
+        assert not hasattr(example, 'z')
+
         # Make the field always fail serialization
         def deserialize(value):
             raise DeserializationError('unable to deserialize {}'.format(value))


### PR DESCRIPTION
Add "strict" option to Model.from_dict() and ModelField.