### PR TITLE
Support arbitrary serializers and deserializers

### DIFF
--- a/serde/model.py
+++ b/serde/model.py
@@ -251,7 +251,7 @@ class Model(metaclass=ModelType):
         Raises:
             `~serde.error.SerializationError`: when the serialization fails.
         """
-        return field.serialize(value)
+        return field._serialize(value)
 
     @classmethod
     @handle_field_errors(DeserializationError)
@@ -266,7 +266,7 @@ class Model(metaclass=ModelType):
         Raises:
             `~serde.error.DeserializationError`: when the deserialization fails.
         """
-        return field.deserialize(value)
+        return field._deserialize(value)
 
     @handle_field_errors(ValidationError)
     def _validate_field(self, field, value):
@@ -291,7 +291,12 @@ class Model(metaclass=ModelType):
         """
         for name, field in self._fields.items():
             value = getattr(self, name)
-            self._validate_field(field, value)
+
+            if value is None:
+                if field.required:
+                    raise ValidationError('{!r} is required'.format(name), field=field, model=self)
+            else:
+                self._validate_field(field, value)
 
     @classmethod
     def from_dict(cls, d, strict=True):

--- a/tests/field/test_core.py
+++ b/tests/field/test_core.py
@@ -41,7 +41,7 @@ class TestField:
 
     def test___repr__(self):
         field = Field(rename='test', required=False)
-        assert repr(field) == "Field(default=None, rename='test', required=False, validators=[])"
+        assert repr(field) == "Field(default=None, deserializers=[], rename='test', required=False, serializers=[], validators=[])"
 
     def test__setattr__(self):
         field = Field()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -200,7 +200,7 @@ class TestModel:
 
         # A more complex Model with a sub Model
         class SubExample(Model):
-            x = Float()
+            x = Float(serializers=[lambda x: x])
 
         class Example(Model):
             a = Int(rename='d')
@@ -255,7 +255,7 @@ class TestModel:
 
         # A more complex Model with a sub Model
         class SubExample(Model):
-            x = Float()
+            x = Float(deserializers=[lambda x: x])
 
         class Example(Model):
             a = Int()


### PR DESCRIPTION
- Fields can now take arbitrary custom serializer and deserializer
functions the same way custom validator functions are given.
- The ValidationError that is raised when Fields are missing now carries
the field and model that caused it.