### PR TITLE
Add Python 3.4 to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 matrix:
   include:
+    - python: 3.4
     - python: 3.5
     - python: 3.6
     - python: 3.7

--- a/serde/util.py
+++ b/serde/util.py
@@ -60,8 +60,9 @@ def zip_until_right(*iterables):
     """
     lefts = iterables[:-1]
     right = iter(iterables[-1])
+    iterables = lefts + (right,)
 
-    yield from zip(*lefts, right)
+    yield from zip(*iterables)
 
     try:
         next(right)


### PR DESCRIPTION
Make zip_until_longest() function work on Python 3.4.