### PR TITLE
Remove MANIFEST.in file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include LICENSE


### PR DESCRIPTION
Because LICENSE is specified in the trove classifiers.