### PR TITLE
Fix some bugs in Model tagging

### DIFF
--- a/src/serde/__init__.py
+++ b/src/serde/__init__.py
@@ -191,6 +191,117 @@ deserializing.
 
 We refer to the ``Person`` subclass as a *variant* of a ``User``.
 
+Customizing Subclassed Models
+-----------------------------
+
+There are 4 types of `Model <serde.model.Model>` tagging and they are each
+described below. These examples only show deserialization, but the tagging does
+work for serialization as well.
+
+Externally tagged
+~~~~~~~~~~~~~~~~~
+
+Externally tagged data uses the tag value as a key and nests the content
+underneath that key. You can enable *external tagging* by setting the ``tag``
+field to ``True``.
+
+::
+
+    >>> class Pet(Model):
+    ...     class Meta:
+    ...         tag = True
+    ...
+    ...     name = fields.Str()
+
+    >>> class Dog(Pet):
+    ...     hates_cats = fields.Bool()
+
+    >>> Pet.from_dict({'Dog': {'name': 'Max', 'hates_cats': True}})
+    Dog(name='Max', hates_cats=True)
+
+Internally tagged
+~~~~~~~~~~~~~~~~~
+
+Internally tagged data stores the tag value at a key of value ``tag``, inside
+the serialized data.  You can enable *internal tagging* by setting the ``tag``
+field to a string value.
+
+::
+
+    >>> class Pet(Model):
+    ...     class Meta:
+    ...         tag = 'species'
+    ...
+    ...     name = fields.Str()
+
+    >>> class Dog(Pet):
+    ...     hates_cats = fields.Bool()
+
+    >>> Pet.from_dict({'species': 'Dog', 'name': 'Max', 'hates_cats': True})
+    Dog(name='Max', hates_cats=True)
+
+Adjacently tagged
+~~~~~~~~~~~~~~~~~
+
+Adjacently tagged data data stores the tag value and the content underneath two
+separate keys.  You can enable *adjacent tagging* by setting the ``tag`` *and*
+content field to string values.
+
+::
+
+    >>> class Pet(Model):
+    ...     class Meta:
+    ...         tag = 'species'
+    ...         content = 'data'
+    ...
+    ...     name = fields.Str()
+
+    >>> class Dog(Pet):
+    ...     hates_cats = fields.Bool()
+
+    >>> Pet.from_dict({'species': 'Dog', 'data': {'name': 'Max', 'hates_cats': True}})
+    Dog(name='Max', hates_cats=True)
+
+Untagged
+~~~~~~~~
+
+Untagged data will try to deserialize each variant in turn. The first variant
+that succeeds deserialization will be returned. You can enable this by setting
+the ``tag`` field to ``False``.
+
+::
+
+    >>> class Pet(Model):
+    ...     class Meta:
+    ...         tag = False
+    ...
+    ...     name = fields.Str()
+
+    >>> class Dog(Pet):
+    ...     hates_cats = fields.Bool()
+
+    >>> Pet.from_dict({'name': 'Max', 'hates_cats': True})
+    Dog(name='Max', hates_cats=True)
+
+Abstract Models
+~~~~~~~~~~~~~~~
+
+All of the above methods allow deserialization of the base Model. It is common
+to have this Model be abstract. You can do this by setting the ``abstract``
+Meta field to ``True``. This will make it uninstantiatable and it won't be
+included in the variant list during deserialization.
+
+::
+
+    >>> class Fruit(Model):
+    ...     class Meta:
+    ...         abstract = True
+
+    >>> Fruit()
+    Traceback (most recent call last):
+        ...
+    serde.exceptions.InstantiationError: unable to instantiate abstract Model 'Fruit'
+
 Model states and processes
 --------------------------
 

--- a/src/serde/__init__.py
+++ b/src/serde/__init__.py
@@ -194,7 +194,7 @@ We refer to the ``Person`` subclass as a *variant* of a ``User``.
 Customizing Subclassed Models
 -----------------------------
 
-There are 4 types of `Model <serde.model.Model>` tagging and they are each
+There are four types of `Model <serde.model.Model>` tagging and they are each
 described below. These examples only show deserialization, but the tagging does
 work for serialization as well.
 

--- a/src/serde/exceptions.py
+++ b/src/serde/exceptions.py
@@ -9,7 +9,6 @@ __all__ = [
     'ContextError',
     'DeserializationError',
     'InstantiationError',
-    'MetaError',
     'NormalizationError',
     'SerdeError',
     'SerializationError',
@@ -71,12 +70,6 @@ class MissingDependency(BaseSerdeError):
 class ContextError(BaseSerdeError):
     """
     Raised when Models or Fields are used in the wrong context.
-    """
-
-
-class MetaError(BaseSerdeError):
-    """
-    Raised when there is a problem with the Model's Meta class.
     """
 
 

--- a/src/serde/utils.py
+++ b/src/serde/utils.py
@@ -34,6 +34,25 @@ def dict_partition(d, keyfunc, dict=OrderedDict):
     return left, right
 
 
+def subclasses(cls):
+    """
+    Returns the recursed subclasses.
+
+    Args:
+        cls (class): the class whose subclasses we should recurse.
+
+    Returns:
+        list: the subclasses.
+    """
+    subs = cls.__subclasses__()
+    variants = []
+
+    for sub in subs:
+        variants.extend(subclasses(sub))
+
+    return subs + variants
+
+
 def try_import(name, package=None):
     """
     Try import the given library, ignoring ImportErrors.

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -158,7 +158,7 @@ class TestSerdeError:
             assert False
         except DeserializationError as e:
             assert e.pretty() == (
-                "DeserializationError: unknown dictionary key 'a'\n"
+                "DeserializationError: unexpected dictionary key 'a'\n"
                 "    Due to => value {'a': 5} for field 'sub' of type 'Nested' on model 'Example'"
             )
 
@@ -172,4 +172,4 @@ class TestSerdeError:
             Example.from_dict({'a': 5, 'b': 'test'})
             assert False
         except DeserializationError as e:
-            assert e.pretty() == "DeserializationError: unknown dictionary key 'b'"
+            assert e.pretty() == "DeserializationError: unexpected dictionary key 'b'"


### PR DESCRIPTION
- Serialization with a modified tag function works properly now.
- Meta classes are passed down to child Models.
- Make Model._normalize_field() an instance method.
- Add Model.__subclasses_recursed__() for recursed variant detection.
- Document Model tagging.